### PR TITLE
Improve performance of `PgDatabaseMetaData.getTypeInfo()` over a network connection with high latency

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -34,12 +34,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class PgDatabaseMetaData implements DatabaseMetaData {
 
   public PgDatabaseMetaData(PgConnection conn) {
     this.connection = conn;
   }
+  private static final Logger LOGGER = Logger.getLogger(PgDatabaseMetaData.class.getName());
 
   private String keywords;
 
@@ -2268,6 +2271,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     f[15] = new Field("SQL_DATA_TYPE", Oid.INT4);
     f[16] = new Field("SQL_DATETIME_SUB", Oid.INT4);
     f[17] = new Field("NUM_PREC_RADIX", Oid.INT4);
+
+    LOGGER.log(Level.FINE, "*** In getTypeInfo() function... ***");
 
     String sql;
     sql = "SELECT t.typname,t.oid FROM pg_catalog.pg_type t"

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -9,6 +9,7 @@ import org.postgresql.core.BaseStatement;
 import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
 import org.postgresql.core.ServerVersion;
+import org.postgresql.core.TypeInfo;
 import org.postgresql.util.ByteConverter;
 import org.postgresql.util.GT;
 import org.postgresql.util.JdbcBlackHole;
@@ -2298,6 +2299,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
               connection.encodeString(Integer.toString(java.sql.DatabaseMetaData.typeNullable));
     byte[] bSearchable =
               connection.encodeString(Integer.toString(java.sql.DatabaseMetaData.typeSearchable));
+
+    TypeInfo ti = connection.getTypeInfo();
+    if (ti instanceof TypeInfoCache) {
+      ((TypeInfoCache) ti).preCacheSQLTypes();
+    }
 
     while (rs.next()) {
       byte[][] tuple = new byte[19][];


### PR DESCRIPTION
PoC change to PostgreSQL JDBC to improve performance of `DatabaseMetadata.getTypeInfo()` over a network connection with high latency.

## Current Status

Currently we've simply created an additional `preCacheSQLTypes()` method in the `TypeInfoCache` class, which is called by `PgDatabaseMetaData.getTypeInfo()` to populate the type cache, before it is queried for each individual pg type.

In our tests with our legacy PowerBuilder application, this change reduced the number of network packets that needed to be sent to the PostgreSQL server from 957 to 14, which reduces the connection time over a connection with 30ms latency from 30 seconds to less than 1 second.

## Possible improvements

This is our first time working on PgJDBC so we're after feedback from more experienced contributors on improvements to this PR (we will also be reviewing the contribution guidelines, running the tests, etc, but want to check if we're on the right track first... :) )

Currently our `preCacheSQLTypes()` method duplicates SQL and Java code from both `PgDatabaseMetaData.getTypeInfo()` (some SQL WHERE conditions), and `TypeInfoCache.getSQLType()` (most of the other code!), so we feel it needs to be improved.

Some improvement ideas:

* Instead of the `preCacheSQLTypes` method, create a `getSQLTypes(List<String> pgTypeNames)` method on the existing `TypeInfoCache` class that takes a list of pgTypeNames (the output from the query in getTypeInfo()). Call this from `getTypeInfo()` to load all the types in one hit. This function will not re-query any types that are already in the cache.
We can also change the `getSQLType()` method to use it too, so as not to duplicate any code. This seems like the cleanest and least impact solution.

* Modify `getSQLType()` so that it always caches all the types on the first request. This may have a slight negative performance + memory impact for apps that only query one or two types.